### PR TITLE
Fixed scroll animation for windows with minimized viewports (devtools…

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -47,7 +47,7 @@ Use the directive in your component template:
 
 ## animationName attribute
 
-The `animationName` attribute is for the name of the CSS class to be added at the time the element appears.  Here is a real-world example if you were using the Animate.css library in your project:
+Required. The `animationName` attribute is for the name(s) of the CSS class(es) to be added at the time the element appears.  Here is a real-world example if you were using the Animate.css library in your project:
 
 ```html
 <div class="container">
@@ -61,12 +61,51 @@ The `animationName` attribute is for the name of the CSS class to be added at th
 </div>
 ```
 
-## offset attribute
-
-You can also optionally add an `offset` attribute (thanks `siegerx3`) to specify the number of pixels offset from the bottom of the viewport when the directive gets triggered on your element.  The default is 80 pixels and the value given would be just the number of pixels.
+or
 
 ```html
-  <div class="animated" animateOnScroll animationName="slideDown" offset="120">
+<div class="container">
+
+  long scrolling content..
+
+  <div animateOnScroll animationName="animated fadeIn">
+    animated content upon appearing in the viewport..
+  </div>
+
+</div>
+```
+
+### Animate.css Peculiarity
+
+If you're using Animate.css with this component and you're trying to animate an element IN to view (fadeIn, slideInLeft etc), you may experience "flashing" when the element scrolls into the viewport (i.e. the element will be shown, then be hidden, then animate into view). This can be mitigated by overriding Animate.css's `.animated` class, then applying `visibility: hidden;` to the element you want to hide:
+
+```css
+.animated {
+    visibility: visible !important;
+}
+.hide-on-init {
+    visibility: hidden;
+}
+```
+
+```html
+<div class="container">
+
+  long scrolling content..
+
+  <div class="hide-on-init" animateOnScroll animationName="animated fadeIn">
+    animated content upon appearing in the viewport..
+  </div>
+
+</div>
+```
+
+## offset attribute
+
+You can also optionally add an `offset` attribute (thanks `siegerx3`) to specify the number of pixels you would need to scroll to *below* the top of the element for the animation to activate. The default is 80 pixels and the value given can be positive or negative.
+
+```html
+  <div animateOnScroll animationName="animated slideDown" offset="120">
     content with different pixel offset specified
   </div>
 ```


### PR DESCRIPTION
- Fixed scroll animation for windows with minimized viewports (devtools open etc) #7 
- Added small optimisation for manageVisibility(); the offsetTop, winHeight and scrollTrigger calculations are no longer performed once the animation class has been applied. This provides a significant performance improvement when many animations used on a single page.
- Added error handling; when animationName is not set, component will throw an error.
- Added the ability to apply multiple css classes with the animationName property. This makes implementation of animate.css more concise should the implementer want to initially hide animated elements (see new help for example), and allows this directive to be used for purposes other than animation (ng2-apply-class-on-scroll? ;)).
- Allowed for negative values in offset @Input() (using a negative value without property [data binding] would result in scrollTrigger being defined as NaN; the offset property is inferred as a string.
- Added id read only property to help in debugging. Not currently in use as console.log statements have been removed for publishing.
- Moved manageVisibility() call into AfterViewInit() and wrapped in setTimeout(); offsetTop was being calculated inaccurately when viewing sites in portrait view - looks like Angular moves some elements after the view has been initialised, and elementRef.nativeElement.getBoundingClientRect().top was returning strange results.
- Updated README to reflect changes.
- All changes should be non-breaking.