### PR TITLE
Make compatible with angular universal

### DIFF
--- a/src/animate-on-scroll.directive.ts
+++ b/src/animate-on-scroll.directive.ts
@@ -124,12 +124,15 @@ export class AnimateOnScrollDirective implements OnInit, OnDestroy, AfterViewIni
    * @returns void
    */
   private getOffsetTop(): void {
+    if (typeof this.elementRef.nativeElement.getBoundingClientRect === 'function') {
+      const viewportTop = this.elementRef.nativeElement.getBoundingClientRect().top;
+      const clientTop = this.elementRef.nativeElement.clientTop;
 
-    const viewportTop = this.elementRef.nativeElement.getBoundingClientRect().top;
-    const clientTop = this.elementRef.nativeElement.clientTop;
-
-    // get vertical position for selected element
-    this.offsetTop = viewportTop + this.scroll.pos - clientTop;
+      // get vertical position for selected element
+      this.offsetTop = viewportTop + this.scroll.pos - clientTop;
+    } else {
+      this.offsetTop = 0
+    }
 
   }
 

--- a/src/animate-on-scroll.directive.ts
+++ b/src/animate-on-scroll.directive.ts
@@ -114,7 +114,7 @@ export class AnimateOnScrollDirective implements OnInit, OnDestroy, AfterViewIni
    */
   private getWinHeight(): void {
 
-    this.winHeight = window ?  window.innerHeight : 0;
+    this.winHeight = typeof window !== 'undefined' ?  window.innerHeight : 0;
 
   }
 

--- a/src/animate-on-scroll.directive.ts
+++ b/src/animate-on-scroll.directive.ts
@@ -114,7 +114,7 @@ export class AnimateOnScrollDirective implements OnInit, OnDestroy, AfterViewIni
    */
   private getWinHeight(): void {
 
-    this.winHeight = window.innerHeight;
+    this.winHeight = window ?  window.innerHeight : 0;
 
   }
 

--- a/src/scroll.service.ts
+++ b/src/scroll.service.ts
@@ -1,7 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Observable, Subscription, empty } from 'rxjs';
-import { fromEvent } from 'rxjs/observable/fromEvent';
-
+import { Observable, Subscription, empty, fromEvent } from 'rxjs';
 
 @Injectable()
 export class ScrollService implements OnDestroy {

--- a/src/scroll.service.ts
+++ b/src/scroll.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Observable, Subscription, fromEvent, empty } from 'rxjs';
+import { Observable, Subscription, empty } from 'rxjs';
+import { fromEvent } from 'rxjs/observable/fromEvent'
+
 
 @Injectable()
 export class ScrollService implements OnDestroy {

--- a/src/scroll.service.ts
+++ b/src/scroll.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Observable, Subscription, empty } from 'rxjs';
-import { fromEvent } from 'rxjs/observable/fromEvent'
+import { fromEvent } from 'rxjs/observable/fromEvent';
 
 
 @Injectable()

--- a/src/scroll.service.ts
+++ b/src/scroll.service.ts
@@ -35,7 +35,7 @@ export class ScrollService implements OnDestroy {
   private manageScrollPos(): void {
 
     // update service property
-    this.pos = window.pageYOffset;
+    this.pos = window ? window.pageYOffset : 0;
 
   }
 

--- a/src/scroll.service.ts
+++ b/src/scroll.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Observable, Subscription, fromEvent } from 'rxjs';
+import { Observable, Subscription, fromEvent, empty } from 'rxjs';
 
 @Injectable()
 export class ScrollService implements OnDestroy {
@@ -16,14 +16,14 @@ export class ScrollService implements OnDestroy {
     this.manageScrollPos();
 
     // create observable that we can subscribe to from component or directive
-    this.scrollObs = fromEvent(window, 'scroll');
+    this.scrollObs = typeof window !== 'undefined' ? fromEvent(window, 'scroll') : empty();
 
     // initiate subscription to update values
     this.scrollSub = this.scrollObs
       .subscribe(() => this.manageScrollPos());
 
     // create observable for changes in screen size
-    this.resizeObs = fromEvent(window, 'resize');
+    this.resizeObs = typeof window !== 'undefined' ? fromEvent(window, 'resize') : empty();
 
     // initiate subscription to update values
     this.resizeSub = this.resizeObs

--- a/src/scroll.service.ts
+++ b/src/scroll.service.ts
@@ -35,7 +35,7 @@ export class ScrollService implements OnDestroy {
   private manageScrollPos(): void {
 
     // update service property
-    this.pos = window ? window.pageYOffset : 0;
+    this.pos = typeof window !== 'undefined' ? window.pageYOffset : 0;
 
   }
 


### PR DESCRIPTION
Angular universal allows for rendering your app server side in node. In order for code to be compatible with it, you need to check for `window` or dom properties like `getBoundingClientRects` before using them.

I just added some simple fallbacks so that including this package wouldn't error when running in angular universal