### PR TITLE
Add Ivy Support

### DIFF
--- a/src/animate-on-scroll.directive.ts
+++ b/src/animate-on-scroll.directive.ts
@@ -102,7 +102,7 @@ export class AnimateOnScrollDirective implements OnInit, OnDestroy, AfterViewIni
   private setClass(classes: string): void {
 
     for (const c of classes.split(' ')) {
-      this.renderer.setElementClass(this.elementRef.nativeElement, c, true);
+      this.renderer.addClass(this.elementRef.nativeElement, c);
     }
 
   }


### PR DESCRIPTION
Fix for #29 

As far as I can tell, this minor change should add support to Ivy. I think it was using a deprecated function previously. See [Renderer2 docs](https://angular.io/api/core/Renderer2#addClass)

@abhazelton do you want to be involved at all with this update?